### PR TITLE
feat: add Backspace key support to calculator

### DIFF
--- a/src/components/Calculator.jsx
+++ b/src/components/Calculator.jsx
@@ -65,6 +65,11 @@ export default function Calculator() {
     setWaitingForOperand(false)
   }, [])
 
+  const handleBackspace = useCallback(() => {
+    if (waitingForOperand) return
+    setDisplay(prev => prev.length > 1 ? prev.slice(0, -1) : '0')
+  }, [waitingForOperand])
+
   useEffect(() => {
     const handleKeyDown = (e) => {
       if (e.key >= '0' && e.key <= '9') {
@@ -78,12 +83,15 @@ export default function Calculator() {
         handleEquals()
       } else if (e.key === 'Escape' || e.key === 'c' || e.key === 'C') {
         handleClear()
+      } else if (e.key === 'Backspace') {
+        e.preventDefault()
+        handleBackspace()
       }
     }
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [handleNumber, handleDecimal, handleOperator, handleEquals, handleClear])
+  }, [handleNumber, handleDecimal, handleOperator, handleEquals, handleClear, handleBackspace])
 
   const buttons = [
     { label: 'C', type: 'clear', action: handleClear },


### PR DESCRIPTION
Adds support for the Backspace key to delete the last digit entered in the calculator, improving usability.

## Cambios

En `src/components/Calculator.jsx`:
- Se agrega la función `handleBackspace` que elimina el último dígito del display
- Se agrega el manejo de la tecla `Backspace` en el listener de teclado existente

Closes #7

Generated with [Claude Code](https://claude.ai/code)