### PR TITLE
fix: Corregir paleta de colores de la calculadora

### DIFF
--- a/src/components/Calculator.css
+++ b/src/components/Calculator.css
@@ -66,21 +66,21 @@
 }
 
 .btn-number {
-  background: #505050;
+  background: #3a3a3c;
   color: #fff;
 }
 
 .btn-operator {
-  background: #0aff2b;
+  background: #ff9500;
   color: #fff;
 }
 
 .btn-clear {
   background: #a5a5a5;
-  color: #000;
+  color: #1c1c1e;
 }
 
 .btn-equals {
-  background: #30d158;
+  background: #e07800;
   color: #fff;
 }


### PR DESCRIPTION
Corrige los colores erróneos de los botones de la calculadora, reemplazando el verde neón con una paleta naranja cálida y tranquila.

Cambios:
- Botones de operadores: #0aff2b → #ff9500 (naranja cálido)
- Botón equals: #30d158 → #e07800 (naranja profundo)
- Botones numéricos: gris suavizado

Resolves #11

Generated with [Claude Code](https://claude.ai/code)