### PR TITLE
fix: corregir renderizado del número 0 en la calculadora

### DIFF
--- a/src/components/Calculator.css
+++ b/src/components/Calculator.css
@@ -36,7 +36,9 @@
 .display-value {
   color: #f0e6ff;
   font-size: 52px;
-  font-weight: 300;
+  font-weight: 400;
+  line-height: 1.1;
+  letter-spacing: -0.5px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
Corrige el solapamiento/renderizado incorrecto de números en el display de la calculadora.

## Cambios
- Cambiado `font-weight: 300` a `font-weight: 400` en `.display-value`
- Añadido `line-height: 1.1` explícito para evitar herencia
- Añadido `letter-spacing: -0.5px` explícito

Cierra #23

Generated with [Claude Code](https://claude.ai/code)