### PR TITLE
fix: eliminar barras blancas en los lados de la calculadora

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -55,11 +55,7 @@ body {
 }
 
 #root {
-  width: 1126px;
-  max-width: 100%;
-  margin: 0 auto;
-  text-align: center;
-  border-inline: 1px solid var(--border);
+  width: 100%;
   min-height: 100svh;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Elimina el ancho fijo y los márgenes del elemento #root en index.css que causaban barras blancas a los lados de la calculadora.

Fixes #27

Generated with [Claude Code](https://claude.ai/code)